### PR TITLE
Fix broken imports

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,8 +2,10 @@ from __future__ import print_function
 
 import struct
 
+from binaryninja.enums import Endianness
+
 from binaryninja import (
-    Architecture, RegisterInfo, InstructionInfo,
+    Architecture, BinaryViewType, RegisterInfo, InstructionInfo,
 
     InstructionTextToken, InstructionTextTokenType,
 


### PR DESCRIPTION
Plugin doesn't load in v1.1.1142 due to missing import. #13 is possibly related.

```
Traceback (most recent call last):
  File "C:\Users\xxx\AppData\Roaming\Binary Ninja\plugins\binja-avr\__init__.py", line 1191, in <module>
    BinaryViewType['ELF'].register_arch(83, Endianness.LittleEndian, Architecture["AVR"])
NameError: name 'BinaryViewType' is not defined
Python plugin 'binja-avr' could not be loaded
Traceback (most recent call last):
  File "C:\Users\xxx\AppData\Roaming\Binary Ninja\plugins\binja-avr\__init__.py", line 1191, in <module>
    BinaryViewType['ELF'].register_arch(83, Endianness.LittleEndian, Architecture["AVR"])
NameError: name 'BinaryViewType' is not defined
Python plugin 'binja-avr' could not be loaded
```